### PR TITLE
print UTF-8 text

### DIFF
--- a/alienfeed/alien.py
+++ b/alienfeed/alien.py
@@ -113,7 +113,7 @@ def submission_getter(submission_list, verbose = False):
             u'{count}{arrow}{score} {title} {tags}'.format(**fmt))
 
         for line in wrap:
-            print line
+            print line.encode("utf8")
 
     return submissions
 


### PR DESCRIPTION
Looks like UTF-8 content was not encoded before printing.
To reproduce: alienfeed de

```
alienfeed berlin
 Top 10 /r/berlin links:
 1 -> 13 Glasfaserkabel zerschnitten: 160.000 Berliner ohne Internet.
 2 ->  2 Any good live music venues on a Monday night? [POST]
Traceback (most recent call last):
  File "/usr/local/bin/alienfeed", line 9, in <module>
    load_entry_point('AlienFeed==0.3.2', 'console_scripts', 'alienfeed')()
  File "/usr/local/bin/alien.py", line 229, in main
    subreddit_viewer(subm_gen)
  File "/usr/local/bin/alien.py", line 71, in subreddit_viewer
    links = submission_getter(generator, verbose=True)
  File "/usr/local/bin/alien.py", line 117, in submission_getter
    print line
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 26: ordinal not in range(128)
```
