### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To download and install AlienFeed, all you need to do is get a copy of this dist
 $ pip install alienfeed
 ```
 
-###Install via setup.py 
+### Install via setup.py 
 Download this zip or clone it to your local machine. Then run the following commands to install AlienFeed.
 
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
